### PR TITLE
bug-fix : Custom generateFilename is Not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function S3Adapter (options, schema) {
 	}
 
 	// Ensure the generateFilename option takes a callback
-	this.options.generateFilename = ensureCallback(this.options.generateFilename);
+	this.options.generateFilename = ensureCallback(options.generateFilename ? options.generateFilename : this.options.generateFilename);
 }
 
 S3Adapter.compatibilityLevel = 1;


### PR DESCRIPTION
when using generateFileName as Storage option
generateFilename option is not working

because keystone-storage-adapter-s3 can be used only DEFAULT_OPTIONS.generateFilename
So I made the generateFilename option to work
thanks you 

``` javascript
const storage = new keystone.Storage({
    adapter: require('keystone-storage-adapter-s3'),
    s3: {
        path: '/files',
        region: 'ap-northeast-1',
        headers: {
            'x-amz-acl': 'public-read'
        },
    },
    schema: {
        bucket: true,
        etag: true,
        path: true,
        url: true,
    },
    generateFilename: customGenerateFileName // it does not working
});
```
