### PR TITLE
Fixed resolving path name for windows  fixes #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ S3Adapter.prototype._resolveFilename = function (file) {
 	// s3.path option. If that doesn't exist we'll assume the file is in the root
 	// of the bucket. (Whew!)
 	var path = file.path || this.options.path || '/';
-	return pathlib.resolve(path, file.filename);
+	return pathlib.posix.resolve(path, file.filename);
 };
 
 S3Adapter.prototype.uploadFile = function (file, callback) {


### PR DESCRIPTION
This fixes an issue  in the s3 upload on windows boxes where the filename contains the fullpath of the file when it arrives on s3. To fix it I've used the posix specific implementation for path.**posix**.resolve(). haven't tested it on linux or mac
