### PR TITLE
Region handling clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ var storage = new keystone.Storage({
     key: 's3-key', // required; defaults to process.env.S3_KEY
     secret: 'secret', // required; defaults to process.env.S3_SECRET
     bucket: 'mybucket', // required; defaults to process.env.S3_BUCKET
+    region: 'ap-southeast-2', // optional; defaults to process.env.S3_REGION, or if that's not specified, us-east-1
     path: '/profilepics',
     headers: {
       'x-amz-acl': 'public-read', // add default headers; see below for details

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var DEFAULT_OPTIONS = {
 	key: process.env.S3_KEY,
 	secret: process.env.S3_SECRET,
 	bucket: process.env.S3_BUCKET,
+	region: process.env.S3_REGION || 'us-east-1',
 	generateFilename: nameFunctions.randomFilename,
 };
 


### PR DESCRIPTION
The docs don't currently specify that `region` is a potential option for the configuration of the bucket. Knox was correctly handing this option, but I think we should make it clear that it's possible to pass this value in, and we should make the default specific and within our control.

This PR does both these things, and I don't believe it'll be a breaking change for people unless they have `process.env.S3_REGION` set for some other reason, but they were depending on the default us-east-1 from Knox to work.
