### PR TITLE
Replacing path.resolve with path.join in _resolveFilename method

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ S3Adapter.prototype._resolveFilename = function (file) {
 	// s3.path option. If that doesn't exist we'll assume the file is in the root
 	// of the bucket. (Whew!)
 	var path = file.path || this.options.path || '/';
-	return pathlib.posix.resolve(path, file.filename);
+	return pathlib.posix.join(path, file.filename);
 };
 
 S3Adapter.prototype.uploadFile = function (file, callback) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "object-assign": "^4.1.0"
   },
   "devDependencies": {
-    "dotenv": "^4.0.0",
+    "dotenv": "^2.0.0",
     "eslint": "^3.2.2",
     "mocha": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "object-assign": "^4.1.0"
   },
   "devDependencies": {
-    "dotenv": "^2.0.0",
+    "dotenv": "^4.0.0",
     "eslint": "^3.2.2",
     "mocha": "^3.0.0"
   },


### PR DESCRIPTION
The current logic in the _resolveFilename method uses path.resolve, which "[resolves a sequence of paths or path segments into an absolute path.](https://nodejs.org/docs/latest/api/path.html#path_path_resolve_paths)"

This means our filename can resolve to:
`/usr/{User}/we/are/not/where/we/want/to/be/{bucket}/our-files-live-here/{filename}`

This is not ideal as the logic default will, in most cases, resolve to the user system root directory. This 'resolvedFilename' would make more sense if the filename is relative to the directory in the s3 bucket, specified in with `path` in the adapter config. ie,
`{bucket}/our-files-live-here/{filename}`

Let me know if I'm off the mark here. @blargity and I had a look and this is what we though would be a good solution, as it solved our use case, but it may need more thinking. Happy to hear any thoughts / suggestions.