### PR TITLE
Paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ S3Adapter.prototype._resolveFilename = function (file) {
 	// s3.path option. If that doesn't exist we'll assume the file is in the root
 	// of the bucket. (Whew!)
 	var path = file.path || this.options.path || '/';
-	return pathlib.posix.resolve(path, file.filename);
+	return pathlib.posix.join(path, file.filename);
 };
 
 S3Adapter.prototype.uploadFile = function (file, callback) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "object-assign": "^4.1.0"
   },
   "devDependencies": {
-    "dotenv": "^4.0.0",
+    "dotenv": "^2.0.0",
     "eslint": "^3.2.2",
     "mocha": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "object-assign": "^4.1.0"
   },
   "devDependencies": {
-    "dotenv": "^2.0.0",
+    "dotenv": "^4.0.0",
     "eslint": "^3.2.2",
     "mocha": "^3.0.0"
   },


### PR DESCRIPTION
Renaming the `path` library from `pathlib` to `path`, as per request --> https://github.com/keystonejs/keystone-storage-adapter-s3/issues/2

Camel casing other ‘path’ suffixed variables, just for consistency.