### PR TITLE
Complete Revamp of Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This adapter is designed to replace the existing `S3File` field in KeystoneJS us
 
 Compatible with Node.js 0.12+
 
+## Thanks to Steven Kaspar
+He did the intial leg work to remove Knox and implement S3 Storage Adapter
+https://github.com/stevenkaspar/keystone-storage-adapter-s3
+
+# Changes
+1. Switch to PUT Object API to preserve Versioning and use best practices
+2. Add mimetype Option to upload to preserve Content-Type header
+3. Update README for clear and correct usage
+
 ## Usage
 
 Configure the storage adapter:
@@ -17,11 +26,28 @@ var storage = new keystone.Storage({
     bucket: 'mybucket', // required; defaults to process.env.S3_BUCKET
     region: 'ap-southeast-2', // optional; defaults to process.env.S3_REGION, or if that's not specified, us-east-1
     path: '/profilepics',
-    headers: {
-      'x-amz-acl': 'public-read', // add default headers; see below for details
-    },
+    // CUSTOM AWS SDK PARAMETERS
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
+    ACL:'public-read',
+    // CacheControl — (String) Specifies caching behavior along the request/reply chain.
+    // ContentDisposition — (String) Specifies presentational information for the object.
+    // ContentEncoding — (String) Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.
+    // ContentLanguage — (String) The language the content is in.
+    // ContentLength — (Integer) Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically.
+    // ContentMD5 — (String) The base64-encoded 128-bit MD5 digest of the part data.
+    // ContentType — (String) A standard MIME type describing the format of the object data.
+    // Expires — (Date) The date and time at which the object is no longer cacheable.
+    // GrantFullControl — (String) Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.
+    // GrantRead — (String) Allows grantee to read the object data and its metadata.
+    // GrantReadACP — (String) Allows grantee to read the object ACL.
+    // GrantWriteACP — (String) Allows grantee to write the ACL for the applicable object.
+    // Key — (String) Object key for which the PUT operation was initiated.
+    // Metadata — (map<String>) A map of metadata to store with the object in S3.
+    publicUrl: file =>  `https://xxxxxxxxx.cloudfront.net/${file.filename}`,
   },
   schema: {
+    mimetype: true | false, // adds Content-Type to your upload
+    size: true | false, // adds Content-Length to your upload
     bucket: true, // optional; store the bucket the file was uploaded to in your db
     etag: true, // optional; store the etag for the resource
     path: true, // optional; store the path of the file in your db

--- a/README.md
+++ b/README.md
@@ -72,24 +72,19 @@ File.add({
 
 The adapter requires an additional `s3` field added to the storage options. It accepts the following values:
 
-- **key**: *(required)* AWS access key. Configure your AWS credentials in the [IAM console](https://console.aws.amazon.com/iam/home?region=ap-southeast-2#home).
+- **AWS_ACCESS_KEY_ID**: *USE ENVIRONMENT VARIABLES* AWS access key. Configure your AWS credentials in the [IAM console](https://console.aws.amazon.com/iam/home?region=ap-southeast-2#home).
 
-- **secret**: *(required)* AWS access secret.
+- **AWS_SECRET_ACCESS_KEY**: *USE ENVIRONMENT VARIABLES* AWS access secret.
 
-- **bucket**: *(required)* S3 bucket to upload files to. Bucket must be created before it can be used. Configure your bucket through the AWS console [here](https://console.aws.amazon.com/s3/home?region=ap-southeast-2).
-
-- **region**: AWS region to connect to. AWS buckets are global, but local regions will let you upload and download files faster. Defaults to `'us-standard'`. Eg, `'us-west-2'`.
+- **params**: *(required)* Use these to setup your storage object. See object above for available options.
 
 - **path**: Storage path inside the bucket. By default uploaded files will be stored in the root of the bucket. You can override this by specifying a base path here. Base path must be absolute, for example '/images/profilepics'.
-
-- **headers**: Default headers to add when uploading files to S3. You can use these headers to configure lots of additional properties and store (small) extra data about the files in S3 itself. See [AWS documentation](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html) for options. Examples: `{"x-amz-acl": "public-read"}` to override the bucket ACL and make all uploaded files globally readable.
-
 
 ### Schema
 
 The S3 adapter supports all the standard Keystone file schema fields. It also supports storing the following values per-file:
 
-- **bucket**, **path**: The bucket, and path within the bucket, for the file can be is stored in the database. If these are present when reading or deleting files, they will be used instead of looking at the adapter configuration. The effect of this is that you can have some (eg, old) files in your collection stored in different bucket / different path inside your bucket.
+- **Bucket**, **path**: The bucket, and path within the bucket, for the file can be is stored in the database. If these are present when reading or deleting files, they will be used instead of looking at the adapter configuration. The effect of this is that you can have some (eg, old) files in your collection stored in different bucket / different path inside your bucket.
 
 The main use of this is to allow slow data migrations. If you *don't* store these values you can arguably migrate your data more easily - just move it all, then reconfigure and restart your server.
 

--- a/README.md
+++ b/README.md
@@ -12,46 +12,49 @@ https://github.com/stevenkaspar/keystone-storage-adapter-s3
 1. Switch to PUT Object API to preserve Versioning and use best practices
 2. Add mimetype Option to upload to preserve Content-Type header
 3. Update README for clear and correct usage
+4. Change JSON structure of S3 adapter
 
 ## Usage
 
 Configure the storage adapter:
 
 ```js
-var storage = new keystone.Storage({
+var s3storage = new keystone.Storage({
   adapter: require('keystone-storage-adapter-s3'),
   s3: {
-    key: 's3-key', // required; defaults to process.env.S3_KEY
-    secret: 'secret', // required; defaults to process.env.S3_SECRET
-    bucket: 'mybucket', // required; defaults to process.env.S3_BUCKET
-    region: 'ap-southeast-2', // optional; defaults to process.env.S3_REGION, or if that's not specified, us-east-1
-    path: '/profilepics',
-    // CUSTOM AWS SDK PARAMETERS
-    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
-    ACL:'public-read',
-    // CacheControl — (String) Specifies caching behavior along the request/reply chain.
-    // ContentDisposition — (String) Specifies presentational information for the object.
-    // ContentEncoding — (String) Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.
-    // ContentLanguage — (String) The language the content is in.
-    // ContentLength — (Integer) Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically.
-    // ContentMD5 — (String) The base64-encoded 128-bit MD5 digest of the part data.
-    // ContentType — (String) A standard MIME type describing the format of the object data.
-    // Expires — (Date) The date and time at which the object is no longer cacheable.
-    // GrantFullControl — (String) Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.
-    // GrantRead — (String) Allows grantee to read the object data and its metadata.
-    // GrantReadACP — (String) Allows grantee to read the object ACL.
-    // GrantWriteACP — (String) Allows grantee to write the ACL for the applicable object.
-    // Key — (String) Object key for which the PUT operation was initiated.
-    // Metadata — (map<String>) A map of metadata to store with the object in S3.
-    publicUrl: file =>  `https://xxxxxxxxx.cloudfront.net/${file.filename}`,
+    params:{
+      Bucket: process.env.S3_BUCKET, // required; defaults to process.env.S3_BUCKET
+      ACL:'public-read',
+      ContentDisposition:"inline",
+      // CUSTOM AWS SDK PARAMETERS
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
+      ACL:'public-read',
+      // CacheControl — (String) Specifies caching behavior along the request/reply chain.
+      // ContentDisposition — (String) Specifies presentational information for the object.
+      // ContentEncoding — (String) Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.
+      // ContentLanguage — (String) The language the content is in.
+      // ContentLength — (Integer) Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically.
+      // ContentMD5 — (String) The base64-encoded 128-bit MD5 digest of the part data.
+      // ContentType — (String) A standard MIME type describing the format of the object data.
+      // Expires — (Date) The date and time at which the object is no longer cacheable.
+      // GrantFullControl — (String) Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.
+      // GrantRead — (String) Allows grantee to read the object data and its metadata.
+      // GrantReadACP — (String) Allows grantee to read the object ACL.
+      // GrantWriteACP — (String) Allows grantee to write the ACL for the applicable object.
+      // Key — (String) Object key for which the PUT operation was initiated.
+      // Metadata — (map<String>) A map of metadata to store with the object in S3.
+    },
+    path:'/',
+    generateFilename: keystone.Storage.originalFilename,
+    publicUrl: file =>  `https://xxxxxxxxx.cloudfront.net/${file.filename}`
   },
   schema: {
-    mimetype: true | false, // adds Content-Type to your upload
-    size: true | false, // adds Content-Length to your upload
+    size:true,
+    mimetype:true,
     bucket: true, // optional; store the bucket the file was uploaded to in your db
     etag: true, // optional; store the etag for the resource
     path: true, // optional; store the path of the file in your db
-    url: true, // optional; generate & store a public URL
+    url: true, // optional; generate & store a public URL,
   },
 });
 ```

--- a/index.js
+++ b/index.js
@@ -3,22 +3,31 @@ TODO
 - Check whether files exist before uploading (will always overwrite as-is)
 - Support multiple retry attempts if a file exists (see FS Adapter)
 */
+/*
+TODO
+- Check whether files exist before uploading (will always overwrite as-is)
+- Support multiple retry attempts if a file exists (see FS Adapter)
+*/
 
 // Mirroring keystone 0.4's support of node 0.12.
 var assign = require('object-assign');
 var debug = require('debug')('keystone-s3');
 var ensureCallback = require('keystone-storage-namefunctions/ensureCallback');
-var knox = require('knox');
+var fs = require('fs');
+var S3 = require('aws-sdk/clients/s3');
 var nameFunctions = require('keystone-storage-namefunctions');
 var pathlib = require('path');
 
 var DEFAULT_OPTIONS = {
-	key: process.env.S3_KEY,
-	secret: process.env.S3_SECRET,
-	bucket: process.env.S3_BUCKET,
-	region: process.env.S3_REGION || 'us-east-1',
+	Bucket: process.env.S3_BUCKET,
 	generateFilename: nameFunctions.randomFilename,
 };
+
+var s3 = new S3({
+	accessKeyId: process.env.S3_KEY,
+	secretAccessKey: process.env.S3_SECRET,
+	region: process.env.S3_REGION || 'us-east-1',
+});
 
 // This constructor is usually called indirectly by the Storage class
 // in keystone.
@@ -39,9 +48,6 @@ function S3Adapter (options, schema) {
 	if (this.options.defaultHeaders) {
 		this.options.headers = this.options.defaultHeaders;
 	}
-
-	// Knox will check for the 'key', 'secret' and 'bucket' options.
-	this.client = knox.createClient(this.options);
 
 	// If path is specified it must be absolute.
 	if (options.path != null && !pathlib.isAbsolute(options.path)) {
@@ -69,20 +75,6 @@ S3Adapter.SCHEMA_FIELD_DEFAULTS = {
 	etag: false,
 };
 
-// Return a knox client configured to interact with the specified file.
-S3Adapter.prototype._knoxForFile = function (file) {
-	// Clients are allowed to store the bucket name in the file structure. If they
-	// do it'll make it possible to have some files in one bucket and some files
-	// in another bucket. The knox client is configured per-bucket, so if you're
-	// using multiple buckets we'll need a different knox client for each file.
-	if (file.bucket && file.bucket !== this.options.bucket) {
-		var s3options = assign({}, this.options, { bucket: file.bucket });
-		return knox.createClient(s3options);
-	} else {
-		return this.client;
-	}
-};
-
 // Get the full, absolute path name for the specified file.
 S3Adapter.prototype._resolveFilename = function (file) {
 	// Just like the bucket, the schema can store the path for files. If the path
@@ -90,7 +82,17 @@ S3Adapter.prototype._resolveFilename = function (file) {
 	// s3.path option. If that doesn't exist we'll assume the file is in the root
 	// of the bucket. (Whew!)
 	var path = file.path || this.options.path || '/';
-	return pathlib.posix.resolve(path, file.filename);
+	var filename = pathlib.posix.resolve(path, file.filename);
+	return (filename.length && filename[0] === '/') ? filename.substring(1) : filename;
+};
+
+S3Adapter.prototype._awsParams = function (file) {
+	if (file && file.bucket && file.bucket !== this.options.Bucket) {
+		var s3options = assign({}, this.options, { Bucket: file.bucket });
+		return s3options;
+	} else {
+		return this.options;
+	}
 };
 
 S3Adapter.prototype.uploadFile = function (file, callback) {
@@ -104,27 +106,42 @@ S3Adapter.prototype.uploadFile = function (file, callback) {
 		// The destination path inside the S3 bucket.
 		file.path = self.options.path;
 		file.filename = filename;
-		var destpath = self._resolveFilename(file);
-
-		// Figure out headers
-		var headers = assign({}, self.options.headers, {
-			'Content-Length': file.size,
-			'Content-Type': file.mimetype,
-		});
+		var fullpath = self._resolveFilename(file);
 
 		debug('Uploading file %s', filename);
-		self.client.putFile(localpath, destpath, headers, function (err, res) {
-			if (err) return callback(err);
-			if (res.statusCode !== 200) {
-				return callback(new Error('Amazon returned status code: ' + res.statusCode));
-			}
-			res.resume(); // Discard (empty) body.
 
+		var fileStream = fs.createReadStream(localpath);
+		fileStream.on('error', function (err) {
+			if (err) return callback(err);
+		});
+
+		var params = assign({}, {
+			Key: fullpath,
+			Body: fileStream,
+		}, self._awsParams());
+
+		// add mimetype to headers
+		// per docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
+		if(file.hasOwnProperty('mimetype')){
+			if(file.mimetype !== undefined && file.mimetype !== null) {
+				params.ContentType = file.mimetype
+			}
+		}
+		if(file.hasOwnProperty('size')){
+			if(file.size !== undefined && file.sizes !== null) {
+				params.ContentLength = file.size
+			}
+		}
+
+		// switch to PUT Object API in order to preserve file versions on S3
+		// this is an AWS SDK best practice
+		s3.putObject(params, function (err, data) {
+			if (err) return callback(err);
 			// We'll annotate the file with a bunch of extra properties. These won't
 			// be saved in the database unless the corresponding schema options are
 			// set.
 			file.filename = filename;
-			file.etag = res.headers.etag; // TODO: This etag is double-quoted (??why?)
+			file.etag = data.ETag; // TODO: This etag is double-quoted (??why?)
 
 			// file.url is automatically populated by keystone's Storage class so we
 			// don't need to set it here.
@@ -136,7 +153,7 @@ S3Adapter.prototype.uploadFile = function (file, callback) {
 			// *don't* store these values you can arguably migrate your data more
 			// easily - just move it all, reconfigure and restart your server.
 			file.path = self.options.path;
-			file.bucket = self.options.bucket;
+			file.bucket = self.options.Bucket;
 
 			debug('file upload successful');
 			callback(null, file);
@@ -152,19 +169,21 @@ S3Adapter.prototype.uploadFile = function (file, callback) {
 S3Adapter.prototype.getFileURL = function (file) {
 	// Consider providing an option to use insecure http. I can't think of any
 	// sensible use case for plain http though. https should be used everywhere.
-	return this._knoxForFile(file).https(this._resolveFilename(file));
+	if (typeof this.options.publicUrl === 'function') {
+		return this.options.publicUrl(file);
+	}
+	return 'https://' + this.options.Bucket + '.s3.amazonaws.com' + (this.options.path.length > 0 ? this.options.path : '') + '/' + file.filename;
 };
 
 S3Adapter.prototype.removeFile = function (file, callback) {
 	var fullpath = this._resolveFilename(file);
-	this._knoxForFile(file).deleteFile(fullpath, function (err, res) {
+
+	var params = assign({}, {
+		Key: fullpath,
+	}, self._awsParams());
+
+	s3.deleteObject(params, function (err, data) {
 		if (err) return callback(err);
-		// Deletes return 204 according to the spec, but we'll allow 200 too:
-		// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html
-		if (res.statusCode !== 200 && res.statusCode !== 204) {
-			return callback(Error('Amazon returned status code ' + res.statusCode));
-		}
-		res.resume(); // Discard the body
 		callback();
 	});
 };
@@ -173,11 +192,14 @@ S3Adapter.prototype.removeFile = function (file, callback) {
 // with the file headers if the file exists, null otherwise.
 S3Adapter.prototype.fileExists = function (filename, callback) {
 	var fullpath = this._resolveFilename({ filename: filename });
-	this.client.headFile(fullpath, function (err, res) {
-		if (err) return callback(err);
 
-		if (res.statusCode === 404) return callback(); // File does not exist
-		callback(null, res.headers);
+	var params = assign({}, {
+		Key: fullpath,
+	}, self._awsParams());
+
+	s3.getObject(params, function (err, data) {
+		if (err) return callback(err);
+		else		 callback(null, data);
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -133,6 +133,8 @@ S3Adapter.prototype.uploadFile = function (file, callback) {
 		// switch to PUT Object API in order to preserve file versions on S3
 		// this is an AWS SDK best practice
 		s3.putObject(params, function (err, data) {
+			console.warn(err)
+			console.warn(data)
 			if (err) return callback(err);
 			// We'll annotate the file with a bunch of extra properties. These won't
 			// be saved in the database unless the corresponding schema options are

--- a/index.js
+++ b/index.js
@@ -88,10 +88,10 @@ S3Adapter.prototype._resolveFilename = function (file) {
 
 S3Adapter.prototype._awsParams = function (file) {
 	if (file && file.bucket && file.bucket !== this.options.Bucket) {
-		var s3options = assign({}, this.options, { Bucket: file.bucket });
+		var s3options = assign({}, this.options.params, { Bucket: file.bucket });
 		return s3options;
 	} else {
-		return this.options;
+		return this.options.params;
 	}
 };
 
@@ -107,9 +107,6 @@ S3Adapter.prototype.uploadFile = function (file, callback) {
 		file.path = self.options.path;
 		file.filename = filename;
 		var fullpath = self._resolveFilename(file);
-
-		debug('Uploading file %s', filename);
-
 		var fileStream = fs.createReadStream(localpath);
 		fileStream.on('error', function (err) {
 			if (err) return callback(err);
@@ -153,7 +150,7 @@ S3Adapter.prototype.uploadFile = function (file, callback) {
 			// *don't* store these values you can arguably migrate your data more
 			// easily - just move it all, reconfigure and restart your server.
 			file.path = self.options.path;
-			file.bucket = self.options.Bucket;
+			file.bucket = DEFAULT_OPTIONS.Bucket;
 
 			debug('file upload successful');
 			callback(null, file);


### PR DESCRIPTION
This version uses the AWS SDK directly and updates the adapter S3 parameter object to take advantage of all the S3 SDK parameters available to the API. Also, it adds headers to requests correctly and uses file.mimetype and file.size to correctly add Content-Type and Content-Length headers to the S3 upload Object. Finally, instead of using "s3.upload" this adapter uses "s3.putObject" which follows the SDK best practices and preserves any versioning that might be enabled on S3