### PR TITLE
replace knox with knox-s3

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ TODO
 var assign = require('object-assign');
 var debug = require('debug')('keystone-s3');
 var ensureCallback = require('keystone-storage-namefunctions/ensureCallback');
-var knox = require('knox');
+var knox = require('knox-s3');
 var nameFunctions = require('keystone-storage-namefunctions');
 var pathlib = require('path');
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/keystonejs/keystone-storage-adapter-s3",
   "dependencies": {
     "debug": "^2.2.0",
-    "knox": "^0.9.2",
+    "knox-s3": "^0.9.5",
     "keystone-storage-namefunctions": "^1.0.0",
     "object-assign": "^4.1.0"
   },


### PR DESCRIPTION
[knox-s3](https://www.npmjs.com/package/knox-s3) is a fork of knox with one difference: a mime 1.x dependency constraint that avoids breaking changes in mime 2.x. See keystonejs/keystone#4498.