### PR TITLE
Define endpoint to use other s3 compatible object storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ var storage = new keystone.Storage({
     region: 'ap-southeast-2', // optional; defaults to process.env.S3_REGION, or if that's not specified, us-east-1
     path: '/profilepics', // optional; defaults to "/"
     publicUrl: "https://xxxxxx.cloudfront.net", // optional; sets a custom domain for public urls - see below for details
+    s3ForcePathStyle: true, //optional; defaults to false, if you use self hosted solutions like minio you probably want to set it to true
     uploadParams: { // optional; add S3 upload params; see below for details
       ACL: 'public-read',
     },
@@ -58,6 +59,8 @@ The adapter requires an additional `s3` field added to the storage options. It a
 - **path**: Storage path inside the bucket. By default uploaded files will be stored in the root of the bucket. You can override this by specifying a base path here. Base path must be absolute, for example '/images/profilepics'.
 
 - **uploadParams**: Default params to pass to the AWS S3 client when uploading files. You can use these params to configure lots of additional properties and store (small) extra data about the files in S3 itself. See [AWS documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) for options. Examples: `{ ACL: "public-read" }` to override the bucket ACL and make all uploaded files globally readable.
+
+- **s3ForcePathStyle**: Whether to force path style URLs for S3 objects. Default is false, which will produce urls like: 'bucketname.amazonaws.com' which could lead to problems with proxies or selfhosted solutions.
 
 - **publicUrl**: Provide a custom domain to serve your S3 files from. This is useful if you are storing in S3 but reading through a CDN like Cloudfront. Provide either the domain as a `string` eg. `publicUrl: "https://xxxxxx.cloudfront.net"` or a function which takes a single parameter `file` and return the full public url to the file.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Configure the storage adapter:
 var storage = new keystone.Storage({
   adapter: require('keystone-storage-adapter-s3'),
   s3: {
+    endpoint: 'https://xxxxxx.amazonaws.com', //optional; defaults to process.env.S3_ENDPOINT, or if that's not specified, https://s3.amazonaws.com as the generic endpoint
     key: 's3-key', // required; defaults to process.env.S3_KEY
     secret: 'secret', // required; defaults to process.env.S3_SECRET
     bucket: 'mybucket', // required; defaults to process.env.S3_BUCKET
@@ -43,6 +44,8 @@ File.add({
 ### Options:
 
 The adapter requires an additional `s3` field added to the storage options. It accepts the following values:
+
+- **endpoint**: Path for different S3 Endpoints, see possible [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for options. You can also set your own minio, ec2, proxy path and more here.
 
 - **key**: *(required)* AWS access key. Configure your AWS credentials in the [IAM console](https://console.aws.amazon.com/iam/home).
 

--- a/index.js
+++ b/index.js
@@ -12,8 +12,10 @@ var debug = require('debug')('keystone-s3');
 var ensureCallback = require('keystone-storage-namefunctions/ensureCallback');
 var nameFunctions = require('keystone-storage-namefunctions');
 var S3 = require('aws-sdk/clients/s3');
+var AWS = require('aws-sdk');
 
 var DEFAULT_OPTIONS = {
+	endpoint: process.env.S3_ENDPOINT || 'https://s3.amazonaws.com',
 	key: process.env.S3_KEY,
 	secret: process.env.S3_SECRET,
 	bucket: process.env.S3_BUCKET,
@@ -75,9 +77,11 @@ function S3Adapter (options, schema) {
 
 	// Create the s3 client
 	this.s3Client = new S3({
+		endpoint: new AWS.Endpoint(this.options.endpoint),
 		accessKeyId: this.options.key,
 		secretAccessKey: this.options.secret,
 		region: this.options.region,
+		s3ForcePathStyle: true,
 	});
 
 	// Ensure the generateFilename option takes a callback

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var DEFAULT_OPTIONS = {
 	secret: process.env.S3_SECRET,
 	bucket: process.env.S3_BUCKET,
 	region: process.env.S3_REGION || 'us-east-1',
+	s3ForcePathStyle: process.env.S3_FORCEPATHSTYLE || false,
 	path: '/',
 	generateFilename: nameFunctions.randomFilename,
 	uploadParams: {},
@@ -81,7 +82,7 @@ function S3Adapter (options, schema) {
 		accessKeyId: this.options.key,
 		secretAccessKey: this.options.secret,
 		region: this.options.region,
-		s3ForcePathStyle: true,
+		s3ForcePathStyle: this.options.s3ForcePathStyle,
 	});
 
 	// Ensure the generateFilename option takes a callback

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -43,6 +43,7 @@ describe('constructor', function () {
 		});
 
 		assert.deepEqual(adapter.options, {
+			endpoint: 'https://s3.amazonaws.com',
 			key: 'key',
 			secret: 'secret',
 			bucket: 'bucket',
@@ -83,12 +84,14 @@ describe('constructor', function () {
 describe('constructor with process.env vars', function () {
 	before(() => {
 		// Store
+		process.env.S3_ENDPOINT = 'env_endpoint';
 		process.env.S3_KEY = 'env_key';
 		process.env.S3_SECRET = 'env_secret';
 		process.env.S3_BUCKET = 'env_bucket';
 		process.env.S3_REGION = 'env_region';
 	});
 	after(() => {
+		delete process.env.S3_ENDPOINT;
 		delete process.env.S3_KEY;
 		delete process.env.S3_SECRET;
 		delete process.env.S3_BUCKET;
@@ -98,6 +101,7 @@ describe('constructor with process.env vars', function () {
 		const StubbedS3Adapter = proxyquire('../index', {});
 		const adapter = new StubbedS3Adapter({ s3: {} });
 		assert.deepEqual(adapter.options, {
+			endpoint: 'env_endpoint',
 			key: 'env_key',
 			secret: 'env_secret',
 			bucket: 'env_bucket',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,6 +48,7 @@ describe('constructor', function () {
 			secret: 'secret',
 			bucket: 'bucket',
 			region: 'us-east-1',
+			s3ForcePathStyle: false,
 			path: '/',
 			generateFilename: nameFunctions.randomFilename,
 			uploadParams: { ACL: 'public-read' },
@@ -89,6 +90,7 @@ describe('constructor with process.env vars', function () {
 		process.env.S3_SECRET = 'env_secret';
 		process.env.S3_BUCKET = 'env_bucket';
 		process.env.S3_REGION = 'env_region';
+		process.env.S3_FORCEPATHSTYLE = 'env_pathstyle';
 	});
 	after(() => {
 		delete process.env.S3_ENDPOINT;
@@ -96,6 +98,7 @@ describe('constructor with process.env vars', function () {
 		delete process.env.S3_SECRET;
 		delete process.env.S3_BUCKET;
 		delete process.env.S3_REGION;
+		delete process.env.S3_FORCEPATHSTYLE;
 	});
 	it('uses process.env variables if provided', function () {
 		const StubbedS3Adapter = proxyquire('../index', {});
@@ -106,6 +109,7 @@ describe('constructor with process.env vars', function () {
 			secret: 'env_secret',
 			bucket: 'env_bucket',
 			region: 'env_region',
+			s3ForcePathStyle: 'env_pathstyle',
 			path: '/',
 			generateFilename: nameFunctions.randomFilename,
 			uploadParams: {},


### PR DESCRIPTION
Related to #37. Add new S3_ENDPOINT and S3_FORCEPATHSTYLE to make it usable with solutions like minio or proxies. Shouldn't cause any problems in existing installations as the default is 'https://s3.amazonaws.com' but it's probably better if someone tests it on some of his projects to make sure that there are no problems with other s3 regions.